### PR TITLE
Fix for Created By picture being too large for its containing cell

### DIFF
--- a/mimeo-vsts-extensions.json
+++ b/mimeo-vsts-extensions.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "id": "mimeo-active-pull-requests",
   "publisher": "mimeo",
-  "version": "0.2.12",
+  "version": "0.2.16",
   "name": "Active Pull Requests",
   "description": "View all active pull requests across all repos in a team.",
   "public": true,

--- a/wwwroot/hub.html
+++ b/wwwroot/hub.html
@@ -28,9 +28,11 @@
         }
 
         .identity-picture {
-            height: 25px;
-            width: 25px;
+            height: 24px !important;
+            width: 24px !important;
             vertical-align: middle;
+            position: relative;
+            top: -3px;
         }
 
         .identity-name {


### PR DESCRIPTION
This fixes a mistake made in the last pull request, where the size of the `.identity-picture` class wasn't getting set properly. This also centers the image within the cell, fixing the cut-off found in previous versions.