### PR TITLE
created base and target branch columns, refactored service for baseUrl

### DIFF
--- a/src/app.models.ts
+++ b/src/app.models.ts
@@ -1,19 +1,22 @@
  /// <reference types="vss-web-extension-sdk" />
-import { IdentityRefWithVote } from "TFS/VersionControl/Contracts";
-import { IdentityRef } from "VSS/WebApi/Contracts";
-
-export interface PullRequest {
-    createdBy: IdentityRef;
-    id: number;
-    url: string;
-    title: string;
-    repo: string;
-    vote: number;
-    reviewers: IdentityRefWithVote[];
-}
-
-export interface Vote {
-    icon: string;
-    message: string;
-    color?: string;
-}
+ import { IdentityRefWithVote } from "TFS/VersionControl/Contracts";
+ import { IdentityRef } from "VSS/WebApi/Contracts";
+ 
+ export interface PullRequest {
+     createdBy: IdentityRef;
+     id: number;
+     baseUri: string;
+     projectName: string;
+     title: string;
+     repo: string;
+     vote: number;
+     reviewers: IdentityRefWithVote[];
+     baseBranch: string;
+     targetBranch: string;
+ }
+ 
+ export interface Vote {
+     icon: string;
+     message: string;
+     color?: string;
+ }

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,7 @@ prClient.getPullRequests().then(prs => {
         // Pull Request ID cell
         const tableCellId = document.createElement("td");
         tableCellId.setAttribute("sorttable_customkey", "" + pr.id);
-        tableCellId.innerHTML = "<a href='" + pr.url + "' target='_top'>Pull Request #" + pr.id + "</a>";
+        tableCellId.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "/pullRequest/" + pr.id) + "' target='_top'>#" + pr.id + "</a>";
         tableRow.appendChild(tableCellId);
         // Title cell
         const tableCellTitle = document.createElement("td");
@@ -32,6 +32,14 @@ prClient.getPullRequests().then(prs => {
         const tableCellRepo = document.createElement("td");
         tableCellRepo.innerText = pr.repo;
         tableRow.appendChild(tableCellRepo);
+        // Base cell
+        const tableCellBaseBranch = document.createElement("td");
+        tableCellBaseBranch.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "?version=GB" + pr.baseBranch) + "' target='_top'>#" + pr.baseBranch + "</a>";
+        tableRow.appendChild(tableCellBaseBranch);
+        // Target cell
+        const tableCellTargetBranch = document.createElement("td");
+        tableCellBaseBranch.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "?version=GB" + pr.targetBranch) + "' target='_top'>#" + pr.targetBranch + "</a>";
+        tableRow.appendChild(tableCellTargetBranch);
         // My Vote cell
         const tableCellVote = document.createElement("td");
         const vote = prClient.voteNumberToVote(pr.vote);

--- a/src/vss-pull-requests.service.ts
+++ b/src/vss-pull-requests.service.ts
@@ -1,109 +1,112 @@
  /// <reference types="vss-web-extension-sdk" />
-import GitRestClient = require("TFS/VersionControl/GitRestClient");
-import { Vote, PullRequest } from "./app.models";
-import { PullRequestStatus, GitPullRequestSearchCriteria, GitRepository } from "TFS/VersionControl/Contracts";
-
-export class VssPullRequests {
-    private client: GitRestClient.GitHttpClient3_1;
-    private projectName: string;
-    private hostUri: string;
-    private user: UserContext;
-
-    constructor() {
-        this.client = GitRestClient.getClient();
-        const context = VSS.getWebContext();
-        this.projectName = context.project.name;
-        this.hostUri = context.host.uri;
-        this.user = context.user;
-    }
-
-    private getPullRequestData(repos: GitRepository[]) {
-        const search: GitPullRequestSearchCriteria = {
-            creatorId: undefined,
-            includeLinks: undefined,
-            repositoryId: undefined,
-            reviewerId: undefined,
-            sourceRefName: undefined,
-            sourceRepositoryId: undefined,
-            status: PullRequestStatus.Active,
-            targetRefName: undefined
-        };
-        return Promise.all(repos.map(repo => {
-            return this.client.getPullRequests(repo.id, search).then(prs => {
-                return prs.map(pr => {
-                    let userVote = -1;
-                    const userAsReviewer = pr.reviewers.filter(reviewer => reviewer.id === this.user.id);
-                    if (userAsReviewer.length === 1) {
-                        userVote = userAsReviewer[0].vote;
-                    }
-                    const pullRequest: PullRequest = {
-                        createdBy: pr.createdBy,
-                        id: pr.pullRequestId,
-                        url: this.hostUri + this.projectName + "/_git/" + repo.name + "/pullRequest/" + pr.pullRequestId,
-                        title: pr.title,
-                        repo: repo.name,
-                        vote: userVote,
-                        reviewers: pr.reviewers
-                    };
-                    return pullRequest;
-                });
-            });
-        }));
-    }
-
-    getPullRequests(): PromiseLike<PullRequest[]> {
-        return this.client.getRepositories(this.projectName, true)
-            .then(repos => this.getPullRequestData(repos)).then(prs => {
-                let unwrappedPrs: PullRequest[] = [];
-                prs.forEach(repoPrGroup => {
-                    unwrappedPrs = unwrappedPrs.concat(repoPrGroup);
-                });
-                return unwrappedPrs;
-            });
-    }
-
-    voteNumberToVote(vote: number): Vote {
-        let voteObj: Vote;
-        switch (vote) {
-            case -10:
-                voteObj = {
-                    icon: "<span class='bowtie-icon bowtie-status-failure'></span>",
-                    message: "Rejected"
-                };
-                break;
-            case -5:
-                voteObj = {
-                    icon: "<span class='bowtie-icon bowtie-status-waiting-fill'></span>",
-                    message: "Waiting for the author"
-                };
-                break;
-            case -1:
-                voteObj = {
-                    icon: "<span class='icon bowtie-icon bowtie-status-waiting bowtie-status-waiting-response'></span>",
-                    message: "No Response (not required)",
-                    color: "#808080"
-                };
-                break;
-            case 0:
-                voteObj = {
-                    icon: "<span class='icon bowtie-icon bowtie-status-waiting bowtie-status-waiting-response'></span>",
-                    message: "Response Required",
-                    color: "#ff0000"
-                };
-                break;
-            case 5:
-                voteObj = {
-                    icon: "<span class='bowtie-icon bowtie-status-success'></span>",
-                    message: "Approved with suggestions"
-                };
-                break;
-            case 10:
-                voteObj = {
-                    icon: "<span class='bowtie-icon bowtie-status-success'></span>",
-                    message: "Approved"
-                };
-                break;
-        }
-        return voteObj;
-    }
-}
+ import GitRestClient = require("TFS/VersionControl/GitRestClient");
+ import { Vote, PullRequest } from "./app.models";
+ import { PullRequestStatus, GitPullRequestSearchCriteria, GitRepository } from "TFS/VersionControl/Contracts";
+ 
+ export class VssPullRequests {
+     private client: GitRestClient.GitHttpClient3_1;
+     private projectName: string;
+     private hostUri: string;
+     private user: UserContext;
+ 
+     constructor() {
+         this.client = GitRestClient.getClient();
+         const context = VSS.getWebContext();
+         this.projectName = context.project.name;
+         this.hostUri = context.host.uri;
+         this.user = context.user;
+     }
+ 
+     private getPullRequestData(repos: GitRepository[]) {
+         const search: GitPullRequestSearchCriteria = {
+             creatorId: undefined,
+             includeLinks: undefined,
+             repositoryId: undefined,
+             reviewerId: undefined,
+             sourceRefName: undefined,
+             sourceRepositoryId: undefined,
+             status: PullRequestStatus.Active,
+             targetRefName: undefined
+         };
+         return Promise.all(repos.map(repo => {
+             return this.client.getPullRequests(repo.id, search).then(prs => {
+                 return prs.map(pr => {
+                     let userVote = -1;
+                     const userAsReviewer = pr.reviewers.filter(reviewer => reviewer.id === this.user.id);
+                     if (userAsReviewer.length === 1) {
+                         userVote = userAsReviewer[0].vote;
+                     }
+                     const pullRequest: PullRequest = {
+                         createdBy: pr.createdBy,
+                         id: pr.pullRequestId,
+                         baseUri: this.hostUri,
+                         projectName: this.projectName,
+                         title: pr.title,
+                         repo: repo.name,
+                         vote: userVote,
+                         reviewers: pr.reviewers,
+                         baseBranch: pr.sourceRefName.replace('refs/heads/', ''),
+                         targetBranch: pr.targetRefName.replace('refs/heads/', '')
+                     };
+                     return pullRequest;
+                 });
+             });
+         }));
+     }
+ 
+     getPullRequests(): PromiseLike<PullRequest[]> {
+         return this.client.getRepositories(this.projectName, true)
+             .then(repos => this.getPullRequestData(repos)).then(prs => {
+                 let unwrappedPrs: PullRequest[] = [];
+                 prs.forEach(repoPrGroup => {
+                     unwrappedPrs = unwrappedPrs.concat(repoPrGroup);
+                 });
+                 return unwrappedPrs;
+             });
+     }
+ 
+     voteNumberToVote(vote: number): Vote {
+         let voteObj: Vote;
+         switch (vote) {
+             case -10:
+                 voteObj = {
+                     icon: "<span class='bowtie-icon bowtie-status-failure'></span>",
+                     message: "Rejected"
+                 };
+                 break;
+             case -5:
+                 voteObj = {
+                     icon: "<span class='bowtie-icon bowtie-status-waiting-fill'></span>",
+                     message: "Waiting for the author"
+                 };
+                 break;
+             case -1:
+                 voteObj = {
+                     icon: "<span class='icon bowtie-icon bowtie-status-waiting bowtie-status-waiting-response'></span>",
+                     message: "No Response (not required)",
+                     color: "#808080"
+                 };
+                 break;
+             case 0:
+                 voteObj = {
+                     icon: "<span class='icon bowtie-icon bowtie-status-waiting bowtie-status-waiting-response'></span>",
+                     message: "Response Required",
+                     color: "#ff0000"
+                 };
+                 break;
+             case 5:
+                 voteObj = {
+                     icon: "<span class='bowtie-icon bowtie-status-success'></span>",
+                     message: "Approved with suggestions"
+                 };
+                 break;
+             case 10:
+                 voteObj = {
+                     icon: "<span class='bowtie-icon bowtie-status-success'></span>",
+                     message: "Approved"
+                 };
+                 break;
+         }
+         return voteObj;
+     }
+ }

--- a/static/index.html
+++ b/static/index.html
@@ -48,6 +48,8 @@
                 <th class="pr-id-header">Id</th>
                 <th>Title</th>
                 <th>Repository</th>
+                <th>Base</th>
+                <th>Target</th>
                 <th>My Vote</th>
                 <th>Reviewers</th>
             </tr>


### PR DESCRIPTION
The line endings are correct as verified by downloading the branch from GitHub as a zip and observing the files as LF.  I'm not sure why it's choking on the diff below.

In `app.model.ts`, I refactored the `url` property to `baseUri` so I could use it for linking directly to the branch (and not just the project).  Azure DevOps was returning the target branch prefixed with `'refs/heads/'`, which I have to assume is consistent across most repositories and most uses of Git.

