### PR TITLE
created base and target branch columns, refactored service for baseUrl

### DIFF
--- a/src/app.models.ts
+++ b/src/app.models.ts
@@ -1,15 +1,18 @@
- /// <reference types="vss-web-extension-sdk" />
+/// <reference types="vss-web-extension-sdk" />
 import { IdentityRefWithVote } from "TFS/VersionControl/Contracts";
 import { IdentityRef } from "VSS/WebApi/Contracts";
 
 export interface PullRequest {
     createdBy: IdentityRef;
     id: number;
-    url: string;
+    baseUri: string;
+    projectName: string;
     title: string;
     repo: string;
     vote: number;
     reviewers: IdentityRefWithVote[];
+    baseBranch: string;
+    targetBranch: string;
 }
 
 export interface Vote {

--- a/src/app.ts
+++ b/src/app.ts
@@ -66,6 +66,6 @@ prClient.getPullRequests().then(prs => {
 }).then(() => sorttable.makeSortable(document.getElementById("pr-table"))).then(() => {
     const prIdHeader = document.getElementsByClassName("pr-id-header")[0];
     sorttable.innerSortFunction.apply(prIdHeader, []);
-    document.getElementById('pr-body').classList.remove('loading');
-    document.getElementById('pr-body').classList.add('loaded');
+    document.getElementById("pr-body").classList.remove("loading");
+    document.getElementById("pr-body").classList.add("loaded");
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,7 +22,7 @@ prClient.getPullRequests().then(prs => {
         // Pull Request ID cell
         const tableCellId = document.createElement("td");
         tableCellId.setAttribute("sorttable_customkey", "" + pr.id);
-        tableCellId.innerHTML = "<a href='" + pr.url + "' target='_top'>Pull Request #" + pr.id + "</a>";
+        tableCellId.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "/pullRequest/" + pr.id) + "' target='_top'>#" + pr.id + "</a>";
         tableRow.appendChild(tableCellId);
         // Title cell
         const tableCellTitle = document.createElement("td");
@@ -32,6 +32,14 @@ prClient.getPullRequests().then(prs => {
         const tableCellRepo = document.createElement("td");
         tableCellRepo.innerText = pr.repo;
         tableRow.appendChild(tableCellRepo);
+        // Base cell
+        const tableCellBaseBranch = document.createElement("td");
+        tableCellBaseBranch.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "?version=GB" + pr.baseBranch) + "' target='_top'>#" + pr.baseBranch + "</a>";
+        tableRow.appendChild(tableCellBaseBranch);
+        // Target cell
+        const tableCellTargetBranch = document.createElement("td");
+        tableCellBaseBranch.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "?version=GB" + pr.targetBranch) + "' target='_top'>#" + pr.targetBranch + "</a>";
+        tableRow.appendChild(tableCellTargetBranch);
         // My Vote cell
         const tableCellVote = document.createElement("td");
         const vote = prClient.voteNumberToVote(pr.vote);

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ prClient.getPullRequests().then(prs => {
     const tableBody = document.getElementById("pr-body");
     console.log("*** pull request data ***", prs);
     prs.forEach(pr => {
+        const repoUrl = pr.baseUri + encodeURIComponent(pr.projectName) + "/_git/" + encodeURIComponent(pr.repo);
         const tableRow = document.createElement("tr");
         tableRow.classList.add("table-row");
         // User Avatar cell
@@ -22,7 +23,7 @@ prClient.getPullRequests().then(prs => {
         // Pull Request ID cell
         const tableCellId = document.createElement("td");
         tableCellId.setAttribute("sorttable_customkey", "" + pr.id);
-        tableCellId.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "/pullRequest/" + pr.id) + "' target='_top'>#" + pr.id + "</a>";
+        tableCellId.innerHTML = "<a href='" + repoUrl + "/pullRequest/" + pr.id + "' target='_top'>#" + pr.id + "</a>";
         tableRow.appendChild(tableCellId);
         // Title cell
         const tableCellTitle = document.createElement("td");
@@ -34,11 +35,11 @@ prClient.getPullRequests().then(prs => {
         tableRow.appendChild(tableCellRepo);
         // Base cell
         const tableCellBaseBranch = document.createElement("td");
-        tableCellBaseBranch.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "?version=GB" + pr.baseBranch) + "' target='_top'>#" + pr.baseBranch + "</a>";
+        tableCellBaseBranch.innerHTML = "<a href='" + repoUrl + "?version=GB" + encodeURIComponent(pr.baseBranch) + "' target='_top'>#" + pr.baseBranch + "</a>";
         tableRow.appendChild(tableCellBaseBranch);
         // Target cell
         const tableCellTargetBranch = document.createElement("td");
-        tableCellBaseBranch.innerHTML = "<a href='" + (pr.baseUri + pr.projectName + "/_git/" + pr.repo + "?version=GB" + pr.targetBranch) + "' target='_top'>#" + pr.targetBranch + "</a>";
+        tableCellBaseBranch.innerHTML = "<a href='" + repoUrl + "?version=GB" + encodeURIComponent(pr.targetBranch) + "' target='_top'>#" + pr.targetBranch + "</a>";
         tableRow.appendChild(tableCellTargetBranch);
         // My Vote cell
         const tableCellVote = document.createElement("td");

--- a/src/vss-pull-requests.service.ts
+++ b/src/vss-pull-requests.service.ts
@@ -1,4 +1,4 @@
- /// <reference types="vss-web-extension-sdk" />
+/// <reference types="vss-web-extension-sdk" />
 import GitRestClient = require("TFS/VersionControl/GitRestClient");
 import { Vote, PullRequest } from "./app.models";
 import { PullRequestStatus, GitPullRequestSearchCriteria, GitRepository } from "TFS/VersionControl/Contracts";
@@ -39,11 +39,14 @@ export class VssPullRequests {
                     const pullRequest: PullRequest = {
                         createdBy: pr.createdBy,
                         id: pr.pullRequestId,
-                        url: this.hostUri + this.projectName + "/_git/" + repo.name + "/pullRequest/" + pr.pullRequestId,
+                        baseUri: this.hostUri,
+                        projectName: this.projectName,
                         title: pr.title,
                         repo: repo.name,
                         vote: userVote,
-                        reviewers: pr.reviewers
+                        reviewers: pr.reviewers,
+                        baseBranch: pr.sourceRefName.replace('refs/heads/', ''),
+                        targetBranch: pr.targetRefName.replace('refs/heads/', '')
                     };
                     return pullRequest;
                 });

--- a/src/vss-pull-requests.service.ts
+++ b/src/vss-pull-requests.service.ts
@@ -45,8 +45,8 @@ export class VssPullRequests {
                         repo: repo.name,
                         vote: userVote,
                         reviewers: pr.reviewers,
-                        baseBranch: pr.sourceRefName.replace('refs/heads/', ''),
-                        targetBranch: pr.targetRefName.replace('refs/heads/', '')
+                        baseBranch: pr.sourceRefName.replace("refs/heads/", ""),
+                        targetBranch: pr.targetRefName.replace("refs/heads/", "")
                     };
                     return pullRequest;
                 });

--- a/static/index.html
+++ b/static/index.html
@@ -48,6 +48,8 @@
                 <th class="pr-id-header">Id</th>
                 <th>Title</th>
                 <th>Repository</th>
+                <th>Base</th>
+                <th>Target</th>
                 <th>My Vote</th>
                 <th>Reviewers</th>
             </tr>


### PR DESCRIPTION
In app.model.ts, I refactored the url property to baseUri so I could use it for linking directly to the branch (and not just the project). Azure DevOps was returning the branches prefixed with 'refs/heads/', which I have to assume is consistent across most repositories and most uses of Git and is safe to remove via `replace`.

The root of my issues with the previous PR is that your reference statements were prefixed with a space.  When I copied and pasted them into VSCode, it indented the entire file with a space and the diff didn't pick up on it.  I don't believe they need the single space indention, do they?