### PR TITLE
removed unnecessary number signs from branch names

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,11 +35,11 @@ prClient.getPullRequests().then(prs => {
         tableRow.appendChild(tableCellRepo);
         // Base cell
         const tableCellBaseBranch = document.createElement("td");
-        tableCellBaseBranch.innerHTML = "<a href='" + repoUrl + "?version=GB" + encodeURIComponent(pr.baseBranch) + "' target='_top'>#" + pr.baseBranch + "</a>";
+        tableCellBaseBranch.innerHTML = "<a href='" + repoUrl + "?version=GB" + encodeURIComponent(pr.baseBranch) + "' target='_top'>" + pr.baseBranch + "</a>";
         tableRow.appendChild(tableCellBaseBranch);
         // Target cell
         const tableCellTargetBranch = document.createElement("td");
-        tableCellTargetBranch.innerHTML = "<a href='" + repoUrl + "?version=GB" + encodeURIComponent(pr.targetBranch) + "' target='_top'>#" + pr.targetBranch + "</a>";
+        tableCellTargetBranch.innerHTML = "<a href='" + repoUrl + "?version=GB" + encodeURIComponent(pr.targetBranch) + "' target='_top'>" + pr.targetBranch + "</a>";
         tableRow.appendChild(tableCellTargetBranch);
         // My Vote cell
         const tableCellVote = document.createElement("td");


### PR DESCRIPTION
Thanks for correcting the bad variable name earlier!  I've realized the number sign/hash tags shouldn't be included in the branch names, so I removed them to make it easier to copy the actual branch name.

No real rush on this...