### PR TITLE
Fix calling the API once per repository for pull request discovery.

### DIFF
--- a/mimeo-vsts-extensions.json
+++ b/mimeo-vsts-extensions.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "mimeo-active-pull-requests",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "name": "All Active Pull Requests",
   "scopes": ["vso.code", "vso.code_status", "vso.build", "vso.profile"],
   "description": "View all active pull requests across all repos in a team.",


### PR DESCRIPTION
I discovered a function for getting pull requests by project on the GitRestClient class while researching the new API library, and after checking the library version we're on, I found it here too. This greatly reduces the number of API calls we're making, as we no longer call the PR endpoint once per repository, nor do we even have to call the repository endpoint anymore.