### PR TITLE
Add Array.prototype.find polyfill for IE.

### DIFF
--- a/mimeo-vsts-extensions.json
+++ b/mimeo-vsts-extensions.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "mimeo-active-pull-requests",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "name": "All Active Pull Requests",
   "scopes": ["vso.code", "vso.code_status", "vso.build", "vso.profile"],
   "description": "View all active pull requests across all repos in a team.",

--- a/static/index.html
+++ b/static/index.html
@@ -21,6 +21,54 @@
             document.head.appendChild(importScript);
         }
     </script>
+    <script type="text/javascript">
+        // array.find polyfill for IE
+        if (!Array.prototype.find) {
+            Object.defineProperty(Array.prototype, 'find', {
+                value: function(predicate) {
+                // 1. Let O be ? ToObject(this value).
+                if (this == null) {
+                    throw new TypeError('"this" is null or not defined');
+                }
+
+                var o = Object(this);
+
+                // 2. Let len be ? ToLength(? Get(O, "length")).
+                var len = o.length >>> 0;
+
+                // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+                if (typeof predicate !== 'function') {
+                    throw new TypeError('predicate must be a function');
+                }
+
+                // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+                var thisArg = arguments[1];
+
+                // 5. Let k be 0.
+                var k = 0;
+
+                // 6. Repeat, while k < len
+                while (k < len) {
+                    // a. Let Pk be ! ToString(k).
+                    // b. Let kValue be ? Get(O, Pk).
+                    // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+                    // d. If testResult is true, return kValue.
+                    var kValue = o[k];
+                    if (predicate.call(thisArg, kValue, k, o)) {
+                    return kValue;
+                    }
+                    // e. Increase k by 1.
+                    k++;
+                }
+
+                // 7. Return undefined.
+                return undefined;
+                },
+                configurable: true,
+                writable: true
+            });
+        }
+    </script>
     <script src="../lib/VSS.SDK.min.js"></script>
     <script src="../lib/sorttable.js"></script>
 </head>


### PR DESCRIPTION
Resolves IE's lack of support for Array.prototype.find causing the extension to stay stuck on "Loading...". This uses the Mozilla-provided polyfill and was tested in IE11.