### PR TITLE
Add Settings Configuration Panel

### DIFF
--- a/mimeo-devops-extension.json
+++ b/mimeo-devops-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "mimeo-active-pull-requests",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "name": "All Active Pull Requests",
   "scopes": ["vso.code", "vso.code_status", "vso.build", "vso.profile"],
   "description": "View all active pull requests across all repos in a project.",

--- a/src/PullRequestTable/PullRequestTable.columns.tsx
+++ b/src/PullRequestTable/PullRequestTable.columns.tsx
@@ -12,6 +12,7 @@ import { IdentityRef } from "azure-devops-extension-api/WebApi/WebApi";
 import { ObservableValue } from "azure-devops-ui/Core/Observable";
 import { getVoteStatus, getCommentStatus } from "./PullRequestTable.helpers";
 import * as styles from "./PullRequestTable.columns.scss";
+import { Settings } from "../SettingsPanel/SettingsPanel.models";
 
 function summonPersona(identityRef: IdentityRef): IIdentityDetailsProvider {
   return {
@@ -24,7 +25,20 @@ function summonPersona(identityRef: IdentityRef): IIdentityDetailsProvider {
   };
 }
 
-export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTableItem>[] {
+export function getColumnTemplate(hostUri: string, settings: Settings): ITableColumn<PullRequestTableItem>[] {
+  if(!settings) {
+    settings = {
+      AuthorColumnEnabled: true,
+      BuildStatusColumnEnabled: true,
+      CommentsColumnEnabled: true,
+      CreatedColumnEnabled: true,
+      DetailsColumnEnabled: true,
+      MyVoteColumnEnabled: true,
+      RepositoryColumnEnabled: true,
+      ReviewersColumnEnabled: true
+    }
+  }
+  
   const renderAuthorColumn = (rowIndex: number, columnIndex: number, tableColumn: ITableColumn<PullRequestTableItem>, tableItem: PullRequestTableItem) => {
     return (
       <SimpleTableCell
@@ -197,9 +211,11 @@ export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTabl
       </SimpleTableCell>
     );
   };
+  
+  let columns = [];
 
-  let columns = [
-    {
+  if(settings.AuthorColumnEnabled) {
+    columns.push({
       columnLayout: TableColumnLayout.singleLinePrefix,
       id: "author",
       name: "Author",
@@ -208,8 +224,11 @@ export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTabl
       onSize: onSize,
       width: new ObservableValue(-25),
       minWidth: 56
-    },
-    {
+    });
+  }
+    
+  if(settings.CreatedColumnEnabled) {
+    columns.push({
       columnLayout: TableColumnLayout.singleLinePrefix,
       id: "creationDate",
       name: "Created",
@@ -218,8 +237,11 @@ export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTabl
       onSize: onSize,
       width: new ObservableValue(130),
       minWidth: 130
-    },
-    {
+    });
+  }
+  
+  if(settings.DetailsColumnEnabled) {
+    columns.push({
       columnLayout: TableColumnLayout.twoLine,
       id: "details",
       name: "Details",
@@ -228,8 +250,11 @@ export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTabl
       onSize: onSize,
       width: new ObservableValue(-50),
       minWidth: 150
-    },
-    {
+    });
+  }
+  
+  if(settings.RepositoryColumnEnabled) {
+    columns.push({
       id: "repository",
       name: "Repository",
       readonly: true,
@@ -237,8 +262,11 @@ export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTabl
       onSize: onSize,
       width: new ObservableValue(-25),
       minWidth: 75
-    },
-    {
+    });
+  }
+
+  if(settings.CommentsColumnEnabled) {
+    columns.push({
       columnLayout: TableColumnLayout.singleLinePrefix,
       id: "comment-status",
       name: "Comments",
@@ -247,8 +275,11 @@ export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTabl
       onSize: onSize,
       width: new ObservableValue(100),
       minWidth: 100
-    },
-    {
+    });
+  }
+
+  if(settings.BuildStatusColumnEnabled) {
+    columns.push({
       columnLayout: TableColumnLayout.singleLinePrefix,
       id: "build-status",
       name: "Build Status",
@@ -257,18 +288,24 @@ export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTabl
       onSize: onSize,
       width: new ObservableValue(-25),
       minWidth: 150
-    },
-    {
-      columnLayout: TableColumnLayout.singleLinePrefix,
-      id: "my-vote",
-      name: "My Vote",
-      readonly: true,
-      renderCell: renderMyVoteColumn,
-      onSize: onSize,
-      width: new ObservableValue(-25),
-      minWidth: 150
-    },
-    {
+    });
+  }
+
+  if(settings.MyVoteColumnEnabled) {
+    columns.push({
+        columnLayout: TableColumnLayout.singleLinePrefix,
+        id: "my-vote",
+        name: "My Vote",
+        readonly: true,
+        renderCell: renderMyVoteColumn,
+        onSize: onSize,
+        width: new ObservableValue(-25),
+        minWidth: 150
+    });
+  }
+
+  if(settings.ReviewersColumnEnabled) {
+    columns.push({
       columnLayout: TableColumnLayout.none,
       id: "reviewers",
       name: "Reviewers",
@@ -276,8 +313,8 @@ export function getColumnTemplate(hostUri: string): ITableColumn<PullRequestTabl
       renderCell: renderReviewersColumn,
       width: new ObservableValue(-33),
       minWidth: 150
-    }
-  ];
+    });
+  }
 
   function onSize(event: MouseEvent, index: number, width: number) {
     (columns[index].width as ObservableValue<number>).value = width;

--- a/src/PullRequestTable/PullRequestTable.models.ts
+++ b/src/PullRequestTable/PullRequestTable.models.ts
@@ -5,17 +5,20 @@ import { ObservableArray, ObservableValue } from "azure-devops-ui/Core/Observabl
 import { IStatusProps } from "azure-devops-ui/Status";
 import { Build } from "azure-devops-extension-api/Build";
 import { ITableColumn } from "azure-devops-ui/Table";
+import { Settings } from "../SettingsPanel/SettingsPanel.models";
 
 export interface PullRequestTableProps {
   pullRequests: PullRequestTableItem[];
   hostUrl: string;
   filter: IFilterState;
+  settings: Settings
 }
 
 export interface PullRequestTableState {
   columns: ITableColumn<PullRequestTableItem>[];
   filteredPrs: PullRequestTableItem[];
   pullRequestProvider: ObservableArray<ObservableValue<PullRequestTableItem>>;
+  settings: Settings
 }
 
 export interface PullRequestTableItem {

--- a/src/PullRequestTable/PullRequestTable.tsx
+++ b/src/PullRequestTable/PullRequestTable.tsx
@@ -20,7 +20,8 @@ export class PullRequestTable extends React.Component<PullRequestTableProps, Pul
   constructor(props: PullRequestTableProps) {
     super(props);
     this.state = {
-      columns: getColumns(this.props.hostUrl),
+      columns: getColumns(this.props.hostUrl, this.props.settings),
+      settings: this.props.settings,
       filteredPrs: [],
       pullRequestProvider: new ObservableArray<ObservableValue<PullRequestTableItem>>(
         this.filterItems(this.props.pullRequests) || new Array(5).fill(new ObservableValue<PullRequestTableItem>(undefined))
@@ -30,7 +31,7 @@ export class PullRequestTable extends React.Component<PullRequestTableProps, Pul
 
   componentDidUpdate(prevProps: PullRequestTableProps, prevState: PullRequestTableState) {
     if (prevProps.hostUrl == null && this.props.hostUrl != null) {
-      this.setState({ columns: getColumns(this.props.hostUrl) });
+      this.setState({ columns: getColumns(this.props.hostUrl, this.props.settings) });
     }
     if (!areArraysEqual(prevProps.pullRequests, this.props.pullRequests) || prevProps.filter !== this.props.filter) {
       this.setState({

--- a/src/SettingsPanel/SettingsPanel.models.ts
+++ b/src/SettingsPanel/SettingsPanel.models.ts
@@ -1,0 +1,36 @@
+import { IExtensionDataManager } from "azure-devops-extension-api";
+
+export enum SettingsColumn {
+  author = "AuthorColumnEnabled",
+  created = "CreatedColumnEnabled",
+  details = "DetailsColumnEnabled",
+  repository = "RepositoryColumnEnabled",
+  comments = "CommentsColumnEnabled",
+  buildStatus = "BuildStatusColumnEnabled",
+  myVote = "MyVoteColumnEnabled",
+  reviewers = "ReviewersColumnEnabled"
+}
+
+export interface Settings {
+  AuthorColumnEnabled: boolean,
+  CreatedColumnEnabled: boolean,
+  DetailsColumnEnabled: boolean,
+  RepositoryColumnEnabled: boolean,
+  CommentsColumnEnabled: boolean,
+  BuildStatusColumnEnabled: boolean,
+  MyVoteColumnEnabled: boolean,
+  ReviewersColumnEnabled: boolean
+}
+
+export interface ISettingsPanelState {
+  dataManager: IExtensionDataManager;
+  settings: Settings;
+  projectName: string
+}
+
+export interface SettingsPanelProps {
+  closeSettings: Function
+  dataManager: IExtensionDataManager;
+  settings: Settings;
+  projectName: string;
+}

--- a/src/SettingsPanel/SettingsPanel.scss
+++ b/src/SettingsPanel/SettingsPanel.scss
@@ -1,0 +1,13 @@
+.settingTitle {
+  border-bottom: solid 1px;
+  padding-bottom: 5px;
+  margin-bottom: 5px;
+}
+
+.settingItem {
+  padding: 2px;
+}
+
+.panelPrimaryButton:hover {
+  background-color: rgb(121, 181, 255) !important;
+}

--- a/src/SettingsPanel/SettingsPanel.tsx
+++ b/src/SettingsPanel/SettingsPanel.tsx
@@ -1,0 +1,136 @@
+import * as React from "react";
+import { Panel } from "azure-devops-ui/Panel";
+import { Toggle } from "azure-devops-ui/Toggle";
+import { SettingsPanelProps, ISettingsPanelState, SettingsColumn } from "./SettingsPanel.models";
+import * as styles from "./SettingsPanel.scss";
+
+export default class SettingsPanel extends React.Component<SettingsPanelProps, ISettingsPanelState> {
+  constructor(props: SettingsPanelProps) {
+    super(props);
+    this.state = { 
+      dataManager: props.dataManager,
+      settings: props.settings,
+      projectName: props.projectName
+    };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div>
+        <Panel
+          onDismiss={() => this.props.closeSettings()}
+          titleProps={{ text: "Extension Settings" }}
+          description={"Modify settings for the All Active Pull Requests extension. Settings only affect your user account for this project."}
+          footerButtonProps={[
+              { text: "Save Changes", primary: true, onClick: () => this.saveSettings(), className:`${styles.panelPrimaryButton}` },
+              { text: "Cancel", onClick: () => this.props.closeSettings() }
+          ]}
+          >
+          <div className="flex-grow rhythm-vertical-8">
+            <div className="flex-column">
+              <div className={`font-size-l font-weight-semibold flex-noshrink flex-grow ${styles.settingTitle}`}>Column Display</div>
+                <div className="body-m secondary-text">
+                  Toggle display of pull request table columns
+                </div>
+            </div>
+                    
+            <div className={`flex-row ${styles.settingItem}`}>
+              <div className="font-size-mm font-weight-semibold flex-noshrink flex-grow">Author</div>
+              <Toggle
+                offText={"Hide"}
+                onText={"Show"}
+                checked={this.state.settings.AuthorColumnEnabled}
+                onChange={(event, value) => { this.updateSetting(value, SettingsColumn.author);}}
+                />
+            </div>
+
+            <div className={`flex-row ${styles.settingItem}`}>
+              <div className="font-size-mm font-weight-semibold flex-noshrink flex-grow">Created</div>
+              <Toggle
+                offText={"Hide"}
+                onText={"Show"}
+                checked={this.state.settings.CreatedColumnEnabled}
+                onChange={(event, value) => { this.updateSetting(value, SettingsColumn.created);}}
+                />
+            </div>
+
+            <div className={`flex-row ${styles.settingItem}`}>
+              <div className="font-size-mm font-weight-semibold flex-noshrink flex-grow">Details</div>
+              <Toggle
+                offText={"Hide"}
+                onText={"Show"}
+                checked={this.state.settings.DetailsColumnEnabled}
+                onChange={(event, value) => { this.updateSetting(value, SettingsColumn.details);}}
+                />
+            </div>
+
+            <div className={`flex-row ${styles.settingItem}`}>
+              <div className="font-size-mm font-weight-semibold flex-noshrink flex-grow">Repository</div>
+              <Toggle
+                offText={"Hide"}
+                onText={"Show"}
+                checked={this.state.settings.RepositoryColumnEnabled}
+                onChange={(event, value) => { this.updateSetting(value, SettingsColumn.repository);}}
+                />
+            </div>
+
+            <div className={`flex-row ${styles.settingItem}`}>
+                <div className="font-size-mm font-weight-semibold flex-noshrink flex-grow">Comments</div>
+                <Toggle
+                  offText={"Hide"}
+                  onText={"Show"}
+                  checked={this.state.settings.CommentsColumnEnabled}
+                  onChange={(event, value) => { this.updateSetting(value, SettingsColumn.comments);}}
+                  />
+            </div>
+
+            <div className={`flex-row ${styles.settingItem}`}>
+                <div className="font-size-mm font-weight-semibold flex-noshrink flex-grow">Build Status</div>
+                <Toggle
+                  offText={"Hide"}
+                  onText={"Show"}
+                  checked={this.state.settings.BuildStatusColumnEnabled}
+                  onChange={(event, value) => { this.updateSetting(value, SettingsColumn.buildStatus);}}
+                  />
+            </div>
+
+            <div className={`flex-row ${styles.settingItem}`}>
+                <div className="font-size-mm font-weight-semibold flex-noshrink flex-grow">My Vote</div>
+                <Toggle
+                  offText={"Hide"}
+                  onText={"Show"}
+                  checked={this.state.settings.MyVoteColumnEnabled}
+                  onChange={(event, value) => { this.updateSetting(value, SettingsColumn.myVote);}}
+                  />
+            </div>
+
+            <div className={`flex-row ${styles.settingItem}`}>
+                <div className="font-size-mm font-weight-semibold flex-noshrink flex-grow">Reviewers</div>
+                <Toggle
+                  offText={"Hide"}
+                  onText={"Show"}
+                  checked={this.state.settings.ReviewersColumnEnabled}
+                  onChange={(event, value) => { this.updateSetting(value, SettingsColumn.reviewers);}}
+                  />
+            </div>
+          </div>
+        </Panel>
+      </div>
+    );
+  }
+
+  private updateSetting(value: boolean, name: SettingsColumn) {
+    var settings = this.state.settings;
+    settings[name] = value;
+
+    this.setState({
+      settings: settings
+    });
+  }
+
+  private saveSettings() {
+    this.state.dataManager!.setValue<string>(`${this.state.projectName}-extension-settings`, JSON.stringify(this.state.settings) || "", { scopeType: "User" }).then(() => {
+      window.location.reload()
+    });
+  }
+}

--- a/src/app.models.tsx
+++ b/src/app.models.tsx
@@ -1,6 +1,7 @@
 import { PullRequestTableItem } from "./PullRequestTable/PullRequestTable.models";
 import { IFilterState } from "azure-devops-ui/Utilities/Filter";
 import { GitRepository } from "azure-devops-extension-api/Git";
+import { Settings } from "./SettingsPanel/SettingsPanel.models";
 
 export interface AppState {
   hostUrl: string;
@@ -10,4 +11,6 @@ export interface AppState {
   activePrBadge: number;
   draftPrBadge: number;
   filter: IFilterState;
+  showSettings: boolean;
+  settings: Settings
 }


### PR DESCRIPTION
Adds a settings panel to toggle display of columns in the pull request table to resolve #56. The settings are stored using the [devops extension storage](https://docs.microsoft.com/en-us/azure/devops/extend/develop/data-storage?view=azure-devops) with the "User" scope to make this a user specific preference. It also prefixes the project name to the storage key to ensure these preferences are project specific. This feature required setting a ready flag once the initial setup has been completed, and using that flag I was also able to resolve #51 by waiting to enable tabs until the setup is complete.

This was tested in my personal devops instance with IE, Edge, Chrome and Firefox

![extension-panel](https://user-images.githubusercontent.com/2201442/61409104-bf579d00-a89e-11e9-915c-aba3ec37e41a.PNG)

![filtered-cols](https://user-images.githubusercontent.com/2201442/61409112-c41c5100-a89e-11e9-800f-52ff4f890ddb.png)



