### PR TITLE
Add sorting to table columns and adjust cell padding

### DIFF
--- a/mimeo-devops-extension.json
+++ b/mimeo-devops-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "mimeo-active-pull-requests",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "name": "All Active Pull Requests",
   "scopes": ["vso.code", "vso.code_status", "vso.build", "vso.profile"],
   "description": "View all active pull requests across all repos in a project.",

--- a/src/PullRequestTable/PullRequestTable.columns.scss
+++ b/src/PullRequestTable/PullRequestTable.columns.scss
@@ -9,3 +9,7 @@
     top: 60%;
   }
 }
+
+.pullRequestColumn {
+  padding: 4px 12px;
+}

--- a/src/PullRequestTable/PullRequestTable.columns.tsx
+++ b/src/PullRequestTable/PullRequestTable.columns.tsx
@@ -45,7 +45,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
         columnIndex={columnIndex}
         tableColumn={tableColumn}
         key={"col-" + columnIndex}
-        contentClassName="fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden">
+        contentClassName={`fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden ${styles.pullRequestColumn}`}>
         <VssPersona identityDetailsProvider={summonPersona(tableItem.author)}
           className="icon-large-margin" size={"medium"} />
         <div className="flex-row scroll-hidden">
@@ -63,7 +63,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
         columnIndex={columnIndex}
         tableColumn={tableColumn}
         key={"col-" + columnIndex}
-        contentClassName="fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden">
+        contentClassName={`fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden ${styles.pullRequestColumn}`}>
         <div className="flex-row scroll-hidden">
           <Tooltip overflowOnly={true}>
             <span className="text-ellipsis"><Ago date={tableItem.creationDate} format={AgoFormat.Compact} /></span>
@@ -77,6 +77,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
     const repoUri = `${hostUri}/_git/${encodeURIComponent(tableItem.repo.name)}`;
     return (
       <TwoLineTableCell
+        className={styles.pullRequestColumn}
         columnIndex={columnIndex}
         tableColumn={tableColumn}
         key={"col-" + columnIndex}
@@ -114,7 +115,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
         columnIndex={columnIndex}
         tableColumn={tableColumn}
         key={"col-" + columnIndex}
-        contentClassName="fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden">
+        contentClassName={`fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden ${styles.pullRequestColumn}`}>
         <div className="flex-row scroll-hidden">
           <Tooltip overflowOnly={true}>
             <span className="text-ellipsis">{tableItem.repo.name}</span>
@@ -128,6 +129,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
     if (tableItem.totalComments == 0) {
       return (
         <SimpleTableCell
+          contentClassName={styles.pullRequestColumn}
           columnIndex={columnIndex}
           tableColumn={tableColumn}
           key={"col-" + columnIndex}>
@@ -136,6 +138,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
     }
     return (
       <SimpleTableCell
+        contentClassName={styles.pullRequestColumn}
         columnIndex={columnIndex}
         tableColumn={tableColumn}
         key={"col-" + columnIndex}>
@@ -153,6 +156,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
     if (tableItem.buildDetails.build == null) {
       return (
         <SimpleTableCell
+          contentClassName={styles.pullRequestColumn}
           columnIndex={columnIndex}
           tableColumn={tableColumn}
           key={"col-" + columnIndex}>
@@ -161,6 +165,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
     }
     return (
       <SimpleTableCell
+        contentClassName={styles.pullRequestColumn}
         columnIndex={columnIndex}
         tableColumn={tableColumn}
         key={"col-" + columnIndex}>
@@ -180,7 +185,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
         columnIndex={columnIndex}
         tableColumn={tableColumn}
         key={"col-" + columnIndex}
-        contentClassName="fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden">
+        contentClassName={`fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden ${styles.pullRequestColumn}`}>
         <Status {...tableItem.vote.status} size={StatusSize.m} className="icon-margin" />
         <div className="flex-row scroll-hidden">
           <Tooltip overflowOnly={true}>
@@ -197,7 +202,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
         columnIndex={columnIndex}
         tableColumn={tableColumn}
         key={"col-" + columnIndex}
-        contentClassName="fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden">
+        contentClassName={`fontWeightSemiBold font-weight-semibold fontSizeM font-size-m scroll-hidden ${styles.pullRequestColumn}`}>
         {
           tableItem.reviewers.map(reviewer =>
             <span className={`${styles.personaWithVote} icon-margin`}>
@@ -223,7 +228,11 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
       renderCell: renderAuthorColumn,
       onSize: onSize,
       width: new ObservableValue(-25),
-      minWidth: 56
+      minWidth: 56,
+      sortProps: {
+        ariaLabelAscending: "Sorted A to Z",
+        ariaLabelDescending: "Sorted Z to A"
+      }
     });
   }
     
@@ -236,7 +245,12 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
       renderCell: renderCreationDateColumn,
       onSize: onSize,
       width: new ObservableValue(130),
-      minWidth: 130
+      minWidth: 130,
+      sortProps: {
+        sortOrder: 0,
+        ariaLabelAscending: "Sorted Oldest to Newest",
+        ariaLabelDescending: "Sorted Newest to Oldest"
+      }
     });
   }
   
@@ -249,7 +263,11 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
       renderCell: renderDetailsColumn,
       onSize: onSize,
       width: new ObservableValue(-50),
-      minWidth: 150
+      minWidth: 150,
+      sortProps: {
+        ariaLabelAscending: "Sorted A to Z",
+        ariaLabelDescending: "Sorted Z to A"
+      }
     });
   }
   
@@ -261,7 +279,11 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
       renderCell: renderRepositoryColumn,
       onSize: onSize,
       width: new ObservableValue(-25),
-      minWidth: 75
+      minWidth: 75,
+      sortProps: {
+        ariaLabelAscending: "Sorted A to Z",
+        ariaLabelDescending: "Sorted Z to A"
+      }
     });
   }
 
@@ -274,7 +296,11 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
       renderCell: renderCommentStatusColumn,
       onSize: onSize,
       width: new ObservableValue(100),
-      minWidth: 100
+      minWidth: 100,
+      sortProps: {
+        ariaLabelAscending: "Sorted Least to Most Resolved",
+        ariaLabelDescending: "Sorted Most to Least Resolved"
+      }
     });
   }
 
@@ -287,7 +313,11 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
       renderCell: renderBuildStatusColumn,
       onSize: onSize,
       width: new ObservableValue(-25),
-      minWidth: 150
+      minWidth: 150,
+      sortProps: {
+        ariaLabelAscending: "Sorted A to Z",
+        ariaLabelDescending: "Sorted Z to A"
+      }
     });
   }
 
@@ -300,7 +330,11 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
         renderCell: renderMyVoteColumn,
         onSize: onSize,
         width: new ObservableValue(-25),
-        minWidth: 150
+        minWidth: 150,
+        sortProps: {
+          ariaLabelAscending: "Sorted A to Z",
+          ariaLabelDescending: "Sorted Z to A"
+        }
     });
   }
 

--- a/src/PullRequestTable/PullRequestTable.tsx
+++ b/src/PullRequestTable/PullRequestTable.tsx
@@ -1,11 +1,12 @@
 import { Card } from "azure-devops-ui/Card";
 import { ObservableArray, ObservableValue } from "azure-devops-ui/Core/Observable";
-import { Table } from "azure-devops-ui/Table";
+import { Table, ColumnSorting, sortItems, SortOrder } from "azure-devops-ui/Table";
 import { ZeroData, ZeroDataActionType } from "azure-devops-ui/ZeroData";
 import * as React from "react";
 import * as zeroImage from "./../../static/images/pullRequest.png";
 import { getColumnTemplate as getColumns } from "./PullRequestTable.columns";
 import { PullRequestTableItem, PullRequestTableProps, PullRequestTableState } from "./PullRequestTable.models";
+import { Settings } from "../SettingsPanel/SettingsPanel.models";
 
 function areArraysEqual(arr1: any[], arr2: any[]): boolean {
   if (arr1 == null || arr2 == null) { return false; }
@@ -27,6 +28,78 @@ export class PullRequestTable extends React.Component<PullRequestTableProps, Pul
         this.filterItems(this.props.pullRequests) || new Array(5).fill(new ObservableValue<PullRequestTableItem>(undefined))
       )
     };
+  }
+
+  private sortingBehavior = new ColumnSorting(
+    (columnIndex: number, proposedSortOrder: SortOrder) => {
+      var newOrder = (this.state.columns[columnIndex].sortProps.sortOrder === 0 /* ascending */ ? 1 /* descending */ : 0 /* ascending */)
+      var items = this.state.pullRequestProvider.value;
+      
+      this.state.pullRequestProvider.splice(
+        0, 
+        this.state.pullRequestProvider.length, 
+        ...sortItems(
+          columnIndex,
+          newOrder,
+          this.sortFunctions(),
+          this.state.columns,
+          items
+        )
+      );
+        
+      this.state.columns[columnIndex].sortProps.sortOrder = newOrder;
+      this.setState({
+        columns: this.state.columns
+      })
+    }
+  );
+
+  private sortFunctions(): ((item1:any, item2:any) => any)[] {
+    let functionsResult = [];
+    
+    if(this.props.settings.AuthorColumnEnabled) {
+      functionsResult.push((item1, item2) => {
+        return item1.value.author.displayName.localeCompare(item2.value.author.displayName);
+      });
+    }
+
+    if(this.props.settings.CreatedColumnEnabled) {
+      functionsResult.push((item1, item2) => {
+        return item1.value.creationDate - item2.value.creationDate;
+      });
+    }
+
+    if(this.props.settings.DetailsColumnEnabled) {
+      functionsResult.push((item1, item2) => {
+        return item1.value.id - item2.value.id;
+      });
+    }
+
+    if(this.props.settings.RepositoryColumnEnabled) {
+      functionsResult.push((item1, item2) => {
+        return item1.value.repo.name.localeCompare(item2.value.repo.name);
+      });
+    }
+
+    if(this.props.settings.CommentsColumnEnabled) {
+      functionsResult.push((item1, item2) => {
+        return (item1.value.totalComments - item1.value.inactiveComments) - (item2.value.totalComments - item2.value.inactiveComments);
+      });
+    }
+
+    if(this.props.settings.BuildStatusColumnEnabled) {
+      functionsResult.push((item1, item2) => {
+        return item1.value.buildDetails.status.message.localeCompare(item2.value.buildDetails.status.message);
+      });
+    }
+
+    if(this.props.settings.MyVoteColumnEnabled) {
+      functionsResult.push((item1, item2) => {
+        return item1.value.vote.message.localeCompare(item2.value.vote.message);
+      });
+    }
+
+    return functionsResult;
   }
 
   componentDidUpdate(prevProps: PullRequestTableProps, prevState: PullRequestTableState) {
@@ -59,7 +132,7 @@ export class PullRequestTable extends React.Component<PullRequestTableProps, Pul
     }
     return (
       <Card className="flex-grow bolt-table-card" contentProps={{ contentPadding: false }}>
-        <Table columns={this.state.columns} itemProvider={this.state.pullRequestProvider} role="table" />
+        <Table columns={this.state.columns} itemProvider={this.state.pullRequestProvider} role="table" behaviors={[this.sortingBehavior]} />
       </Card>
     );
   }


### PR DESCRIPTION
Re-implements sorting functionality on all columns (except reviewers) to resolve #57. Reviewers column is not sortable as it is an array of objects. Also fixes #60 to reduce the padding of each PR row, though 2px felt too tight so I went with 4px. 

Tested in my personal devops instance with Chrome, Edge, IE and Firefox

![sort-example](https://user-images.githubusercontent.com/2201442/62095905-0d758480-b23f-11e9-9225-06390583c16e.png)
