### PR TITLE
Fix for "Pending" comments

### DIFF
--- a/mimeo-devops-extension.json
+++ b/mimeo-devops-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "mimeo-active-pull-requests",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "name": "All Active Pull Requests",
   "scopes": ["vso.code", "vso.code_status", "vso.build", "vso.profile"],
   "description": "View all active pull requests across all repos in a project.",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -153,7 +153,7 @@ export class App extends React.Component<{}, AppState> {
             if (threadStatus) {
               pr.totalComments++;
               // thread status of 1 is 'active'
-              if (threadStatus !== "1") {
+              if (threadStatus !== "1" && threadStatus !== "6") {
                 pr.inactiveComments++;
               }
             }


### PR DESCRIPTION
Fix for #63 - comments marked as "Pending" are showing as resolved instead of the correct unresolved status. Fix tested in my personal devops instance.

Note - I bumped this to 1.1.5 in anticipation my other PR will be completed first with 1.1.4