### PR TITLE
Build PR/repo links from GitRepository.webUrl instead of document.referrer

### DIFF
--- a/src/PullRequestTable/PullRequestTable.columns.tsx
+++ b/src/PullRequestTable/PullRequestTable.columns.tsx
@@ -26,7 +26,7 @@ function summonPersona(identityRef: IdentityRef): IIdentityDetailsProvider {
   };
 }
 
-export function getColumnTemplate(hostUri: string, settings: Settings): ITableColumn<PullRequestTableItem>[] {
+export function getColumnTemplate(settings: Settings): ITableColumn<PullRequestTableItem>[] {
   if(!settings) {
     settings = {
       AuthorColumnEnabled: true,
@@ -75,7 +75,7 @@ export function getColumnTemplate(hostUri: string, settings: Settings): ITableCo
   };
 
   const renderDetailsColumn = (rowIndex: number, columnIndex: number, tableColumn: ITableColumn<PullRequestTableItem>, tableItem: PullRequestTableItem) => {
-    const repoUri = `${hostUri}/_git/${encodeURIComponent(tableItem.repo.name)}`;
+    const repoUri = tableItem.repo.webUrl;
     return (
       <TwoLineTableCell
         className={styles.pullRequestColumn}

--- a/src/PullRequestTable/PullRequestTable.models.ts
+++ b/src/PullRequestTable/PullRequestTable.models.ts
@@ -9,7 +9,6 @@ import { Settings } from "../SettingsPanel/SettingsPanel.models";
 
 export interface PullRequestTableProps {
   pullRequests: PullRequestTableItem[];
-  hostUrl: string;
   filter: IFilterState;
   settings: Settings
 }

--- a/src/PullRequestTable/PullRequestTable.tsx
+++ b/src/PullRequestTable/PullRequestTable.tsx
@@ -20,7 +20,7 @@ export class PullRequestTable extends React.Component<PullRequestTableProps, Pul
   constructor(props: PullRequestTableProps) {
     super(props);
     this.state = {
-      columns: getColumns(this.props.hostUrl, this.props.settings),
+      columns: getColumns(this.props.settings),
       settings: this.props.settings,
       filteredPrs: [],
       pullRequestProvider: new ObservableArray<ObservableValue<PullRequestTableItem>>(
@@ -102,9 +102,6 @@ export class PullRequestTable extends React.Component<PullRequestTableProps, Pul
   }
 
   componentDidUpdate(prevProps: PullRequestTableProps, prevState: PullRequestTableState) {
-    if (prevProps.hostUrl == null && this.props.hostUrl != null) {
-      this.setState({ columns: getColumns(this.props.hostUrl, this.props.settings) });
-    }
     if (!areArraysEqual(prevProps.pullRequests, this.props.pullRequests) || prevProps.filter !== this.props.filter) {
       this.setState({
         pullRequestProvider: new ObservableArray<ObservableValue<PullRequestTableItem>>(

--- a/src/app.models.tsx
+++ b/src/app.models.tsx
@@ -4,7 +4,6 @@ import { GitRepository } from "azure-devops-extension-api/Git";
 import { Settings } from "./SettingsPanel/SettingsPanel.models";
 
 export interface AppState {
-  hostUrl: string;
   pullRequests: PullRequestTableItem[];
   repositories: GitRepository[];
   selectedTabId: string;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -57,7 +57,6 @@ export class App extends React.Component<{}, AppState> {
     this.buildClient = API.getClient(BuildRestClient);
     this.filter = new Filter();
     this.state = {
-      hostUrl: undefined,
       showSettings: false,
       filter: {},
       repositories: [],
@@ -120,7 +119,6 @@ export class App extends React.Component<{}, AppState> {
     const extensionContext = SDK.getExtensionContext();
     console.log(`You're using version ${extensionContext.version} of All Active Pull Requests.`);
 
-    const hostContext = SDK.getHost();
     this.userContext = SDK.getUser();
     const accessToken = await SDK.getAccessToken();
     const projectService = await SDK.getService<IProjectPageService>(CommonServiceIds.ProjectPageService);
@@ -132,19 +130,7 @@ export class App extends React.Component<{}, AppState> {
     const repos = (await this.gitClient.getRepositories(this.projectName)).sort((a, b) => a.name.localeCompare(b.name));
     const pullRequests = await this.getAllPullRequests(this.projectName);
 
-    const parentUrl = new URL(document.referrer);
-    let baseUrl = parentUrl.origin;
-    if (parentUrl.pathname.split('/')[1] === 'tfs') {
-      baseUrl += `/tfs/${hostContext.name}/${this.projectName}`;
-    } else if (parentUrl.hostname.endsWith('visualstudio.com')) {
-      baseUrl += `/${this.projectName}`;
-    } else {
-      baseUrl += `/${hostContext.name}/${this.projectName}`;
-    }
-    console.log('base URL', baseUrl);
-    
     this.setState({
-      hostUrl: baseUrl,
       settings: settings,
       repositories: repos,
       pullRequests: pullRequests.sort(this.defaultSortPrs),
@@ -245,13 +231,13 @@ export class App extends React.Component<{}, AppState> {
       return <section className="page-content page-content-top">
         <PullRequestTable pullRequests={
           this.state.pullRequests ? this.state.pullRequests.filter(x => !x.isDraft) : undefined
-        } hostUrl={this.state.hostUrl} filter={this.state.filter} settings={this.state.settings} />
+        } filter={this.state.filter} settings={this.state.settings} />
       </section>;
     } else if (this.state.selectedTabId === TabType.drafts) {
       return <section className="page-content page-content-top">
         <PullRequestTable pullRequests={
           this.state.pullRequests ? this.state.pullRequests.filter(x => x.isDraft && x.author.id === this.userContext.id) : undefined
-        } hostUrl={this.state.hostUrl} filter={this.state.filter} settings={this.state.settings} />
+        } filter={this.state.filter} settings={this.state.settings} />
       </section>;
     }
     return <div></div>;


### PR DESCRIPTION
## Summary

PR/repo links were being built by reconstructing the org base URL from `document.referrer` and `SDK.getHost()`. Inside Azure DevOps' nested-iframe extension hosting, `document.referrer` can resolve to the extension content frame's own origin on the marketplace gallery CDN (e.g. `mimeo-vs-marketplace.gallerycdn.vsassets.io`) instead of the top-level `dev.azure.com` page. That wrong origin then had `/_git/{repo}/pullRequest/{id}` appended to it, producing broken links like:

```
http://mimeo-vs-marketplace.gallerycdn.vsassets.io/rightrez/RightRez/_git/RightStack.Client/pullRequest/7643
```

which Akamai's WAF rejects with "Access Denied".

The Git REST API already returns the correct web URL on every repository (`GitRepository.webUrl`), and `PullRequestTableItem.repo` already carries the full object - so this replaces the whole `document.referrer`/`hostContext` reconstruction with `repo.webUrl` directly, and removes the now-dead `hostUrl` plumbing through `App` → `PullRequestTable` → `getColumnTemplate`.

This also removes the manual org/project string-concatenation logic that previously caused #79 (already fixed in #80/`e014935`, which this change replaces wholesale) - that class of bug can no longer occur since org and project names are never parsed or concatenated by client code again.

## Verification

This repo has no test runner (only `tslint`). I verified:
- `tsc --noEmit -p .` - clean, exit 0
- `npm run lint` - clean, exit 0
- A standalone script reproducing the old `document.referrer`-based logic against the exact reported bug (confirms it produces the broken CDN URL) alongside the new `repo.webUrl`-based logic (confirms it produces the correct URL and is unaffected by the same bad referrer context)
- Confirmed `GitRepository.webUrl` exists and is populated on the `azure-devops-extension-api@^1.153.2` version this project actually depends on (checked the installed type definitions directly, not just a newer package version)
- No dangling references to `hostUrl`/`hostUri`/`hostContext`/`document.referrer` anywhere in `src/`

`npm run build` (webpack + node-sass) doesn't run in my environment - `node-sass`'s native module fails to compile under modern Node/Python (pre-existing toolchain issue unrelated to this change; there's already a dependabot PR open bumping `node-sass` to 7.0.0). TypeScript compilation and lint are clean, which covers the actual code changed here.

## Test plan

- [ ] Install the extension build from this branch in a real Azure DevOps org and confirm PR/repo links resolve correctly (I don't have a build environment that produces a working `.vsix` here - see verification note above)
- [x] `tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] Standalone regression script confirms old vs. new URL-building behavior